### PR TITLE
Add logs API

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The **Expense Tracker API** is a robust and secure RESTful web service that enab
 - [Authentication](#authentication)
 - [Expense Management](#expense-management)
 - [User Profile](#user-profile)
+- [Logs](#logs)
 
 ---
 
@@ -101,3 +102,12 @@ Update the user's profile information, enabling users to modify their first name
 Deactivate the user's account, allowing users to terminate their profile and associated data.
 
 ---
+
+## Logs
+
+### Fetch Application Logs
+
+**Endpoint:** `GET /logs`
+
+Retrieve the contents of the server log file for troubleshooting purposes.
+

--- a/src/main/java/org/expensetrackerapi/controller/LogController.java
+++ b/src/main/java/org/expensetrackerapi/controller/LogController.java
@@ -1,0 +1,28 @@
+package org.expensetrackerapi.controller;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class LogController {
+
+    @Value("${logging.file.name:app.log}")
+    private String logFile;
+
+    @GetMapping("/logs")
+    public ResponseEntity<String> getLogs() throws IOException {
+        Path path = Paths.get(logFile);
+        if (Files.exists(path)) {
+            String content = new String(Files.readAllBytes(path));
+            return ResponseEntity.ok(content);
+        }
+        return ResponseEntity.notFound().build();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,3 +15,4 @@ spring.jpa.show-sql=true
 server.servlet.context-path=/api/anurag
 
 jwt.secret=b2tech
+logging.file.name=app.log


### PR DESCRIPTION
## Summary
- log to file with Spring Boot
- add a controller to expose `/logs`
- document new logs endpoint

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845895a88d8832181ea4959b44571dc